### PR TITLE
Fix crash when no class level permissions are present

### DIFF
--- a/parse_schema_validator/schema_validator.py
+++ b/parse_schema_validator/schema_validator.py
@@ -189,7 +189,7 @@ def main():
 
         if command_args.dump:
             for item in parse_classes:
-                del item['classLevelPermissions']
+                item.pop('classLevelPermissions', None)
             print(json.dumps({'classes': parse_classes},
                              indent=2, sort_keys=True))
         elif command_args.schema:


### PR DESCRIPTION
I was trying to get a schema dump from a parse.com hosted app and I got the following error:

```
Traceback (most recent call last):
  File "/Users/jeethu/anaconda/envs/py2/bin/parse-schema-validator", line 11, in <module>
    sys.exit(main())
  File "/Users/jeethu/anaconda/envs/py2/lib/python2.7/site-packages/parse_schema_validator/schema_validator.py", line 192, in main
    del item['classLevelPermissions']
KeyError: 'classLevelPermissions'
```

The fix was a one liner.
